### PR TITLE
IGDD-2124 - Add job to GitHub Action to push image to APHL on release.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - develop
       - 'release/**'
-      - 'IGDD-2124_Push-image-to-aphl'
 
 env:
   GITHUB_REGISTRY_PREFIX: ghcr.io
@@ -126,7 +125,7 @@ jobs:
   build-and-push-aphl:
     name: 'Push Image To APHL'
     runs-on: ubuntu-latest
-    if: ${{ contains(github.ref, 'refs/heads/release/') || github.ref == 'refs/heads/IGDD-2124_Push-image-to-aphl' }}
+    if: ${{ contains(github.ref, 'refs/heads/release/') }}
     needs: [code-quality-check, generate-release-timestamp]
     permissions:
       contents: write
@@ -163,10 +162,10 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ${{ secrets.APHL_ECR_REGISTRY }}/${{ secrets.APHL_ECR_REPOSITORY }},enable=${{ contains(github.ref, 'refs/heads/release/') || github.ref == 'refs/heads/IGDD-2124_Push-image-to-aphl' }}
+            ${{ secrets.APHL_ECR_REGISTRY }}/${{ secrets.APHL_ECR_REPOSITORY }},enable=${{ contains(github.ref, 'refs/heads/release/') }}
           tags: |
             type=raw,value=izg-configuration-console_${{ needs.generate-release-timestamp.outputs.releaseDate }}
-            type=raw,value=izg-configuration-console_rc_${{ needs.generate-release-timestamp.outputs.releaseDate }},enable=${{ contains(github.ref, 'refs/heads/release/') || github.ref == 'refs/heads/IGDD-2124_Push-image-to-aphl' }}
+            type=raw,value=izg-configuration-console_rc_${{ needs.generate-release-timestamp.outputs.releaseDate }},enable=${{ contains(github.ref, 'refs/heads/release/') }}
             type=raw,value=izg-configuration-console_release_${{ needs.generate-release-timestamp.outputs.releaseDate }},enable=${{ github.ref == 'refs/heads/main' }}
           flavor: |
             latest=false


### PR DESCRIPTION
So that APHL doesn't have to manually pull image for IZG CC during the next release.