### PR TITLE
IGDD-2169 - Update nginx.conf to set read timeout via environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN adduser --system --uid 1001 nextjs
 RUN apk add bash
 
 # Install Nginx, gettext (for envsubst), and tini
-RUN apk add --no-cache nginx tini
+RUN apk add --no-cache nginx gettext tini
 
 COPY prisma ./prisma/
 COPY package.json package-lock.json ./
@@ -54,9 +54,9 @@ RUN apk add curl libc6-compat
      rm -rf /metricbeat.yml && \
      cp ../app/metricbeat.yml ./metricbeat.yml
 
-# Configure Nginx
+# Copy Nginx Configuration Template
 RUN mkdir -p /etc/nginx/conf.d
-COPY nginx.conf /etc/nginx/nginx.conf
+COPY nginx.conf.template /app/nginx.conf.template
 
 #USER nextjs
 RUN chmod a+x replace-variable.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       ELASTIC_API_KEY: ${ELASTIC_API_KEY}
       ELASTIC_INDEX: ${ELASTIC_INDEX}
       ELASTIC_INDEX_NGINX: ${ELASTIC_INDEX_NGINX}
+      NGINX_READ_TIMEOUT: ${NGINX_READ_TIMEOUT}
     volumes:
       - type: bind
         source: ${SSL_SOURCE}

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -60,6 +60,7 @@ http {
             proxy_buffer_size          128k;
             proxy_buffers              4 256k;
             proxy_busy_buffers_size    256k;
+            proxy_read_timeout ${NGINX_READ_TIMEOUT};
         }
     }
 }

--- a/run_and_monitor.sh
+++ b/run_and_monitor.sh
@@ -53,9 +53,18 @@ openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
 -out /etc/nginx/ssl/cert.pem \
 -subj "/C=US/ST=State/L=City/O=Organization/CN=localhost"
 
-# ***************
-# * Start nginx *
-# ***************
+# *****************************
+# * Configure and start nginx *
+# *****************************
+
+# Set default value if NGINX_READ_TIMEOUT is not set
+export NGINX_READ_TIMEOUT=${NGINX_READ_TIMEOUT:-60s}
+
+# Process the nginx configuration template
+envsubst '${NGINX_READ_TIMEOUT}' < /app/nginx.conf.template > /etc/nginx/nginx.conf
+
+log_message "nginx configuration processed, proxy_read_timeout set to: $NGINX_READ_TIMEOUT"
+
 nginx -g 'daemon off;' &
 NGINX_PID=$!
 log_message "nginx started, PID $NGINX_PID"


### PR DESCRIPTION
Will default to 60s (which is nginx default) if environment variable isn't specified.

Rename nginx.conf to nginx.conf.template as we will be replacing the environment variable with a value.

Update Dockerfile to install gettext (for envsubst) and to copy the nginx.conf.template to /app instead of copying the old nginx.conf.

Update run_and_monitor.sh to use envsubst to set the nginx read timeout from environment variable.