### PR TITLE
IGDD-2243: Update GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20.x'
+          node-version: '24.x'
       - name: Get current date
         id: date
         run: echo "RELEASE_DATE=$(date +'%d%b%Y%H%M%S')" >> "$GITHUB_ENV"
@@ -58,7 +58,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20.x'
+          node-version: '24.x'
       - name: Install Dependencies
         run: npm ci --force
       # - name: Run Jest Unit Tests
@@ -106,7 +106,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20.x'
+          node-version: '24.x'
       - name: Get current date
         id: date
         run: echo "RELEASE_DATE=$(date +'%d%b%Y%H%M%S')" >> "$GITHUB_ENV"
@@ -53,7 +53,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20.x'
+          node-version: '24.x'
       - name: Install Dependencies
         run: npm ci --force
       # - name: Run Jest Unit Tests
@@ -100,7 +100,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -162,7 +162,7 @@ jobs:
             ${{ runner.os }}-nextjs-
 
       - name: Configure AWS credentials (APHL)
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.APHL_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.APHL_AWS_SECRET_ACCESS_KEY }}
@@ -205,7 +205,7 @@ jobs:
       (github.event_name == 'pull_request' && github.base_ref == 'develop')
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/playwright-nightly.yml
+++ b/.github/workflows/playwright-nightly.yml
@@ -29,10 +29,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20.x'
+          node-version: '24.x'
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Update all GitHub Action workflows to use Node.js 24.x instead of 20.x,
and upgrade aws-actions/configure-aws-credentials from v1-node16 to v4.

## Context and Motivation

GitHub announced the deprecation of Node 20 on GitHub Actions runners,
with the end-of-life date set for April 2026. Starting March 4, 2026,
runners will use Node 24 by default. This change is necessary to ensure
our CI/CD pipelines continue to function properly beyond the deprecation
deadline and to stay current with GitHub's supported runtime versions.

Reference: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Changes Made

### Node.js Version Updates (20.x → 24.x)

Updated the following workflow files to use Node 24:

1. **create-release-branch.yml**
   - generate-release-timestamp job: Updated actions/setup-node to 24.x
   - code-quality-check job: Updated actions/setup-node to 24.x

2. **deploy.yml**
   - generate-release-timestamp job: Updated actions/setup-node to 24.x
   - code-quality-check job: Updated actions/setup-node to 24.x

3. **playwright-nightly.yml**
   - e2e job: Updated actions/setup-node to 24.x

### AWS Credentials Action Updates (v1-node16 → v4)

Updated aws-actions/configure-aws-credentials from v1-node16 to v4 in
all workflow files. This update was necessary because:

1. **Node 16 is deprecated**: The v1-node16 version was built for Node 16,
   which GitHub deprecated for actions earlier. Continuing to use this
   version would create a dependency on an unsupported runtime.

2. **Compatibility with modern runners**: Version v4 uses Node 20 internally
   but is fully compatible with GitHub runners using Node 24. The action's
   internal Node version can differ from the runner's Node version without
   causing compatibility issues.

3. **Bug fixes and security updates**: v4 includes numerous improvements,
   bug fixes, and security patches not available in v1, including better
   error handling, improved role chaining, and support for environment
   variable inputs.

4. **Future maintenance**: Using v4 ensures we're on a supported version
   that will continue to receive updates and security patches. v1-node16
   is effectively end-of-life.

Files updated:
- create-release-branch.yml (1 occurrence)
- deploy.yml (3 occurrences: dev AWS, APHL, and deploy-dev job)
- playwright-nightly.yml (1 occurrence)

## Testing Considerations

These changes maintain backward compatibility with existing workflow
configurations. No changes to secrets, environment variables, or workflow
logic were required. The updated actions will be tested automatically when:

1. Pull requests are created against the develop branch (deploy.yml)
2. Pushes are made to release branches (deploy.yml)
3. The create release branch workflow is triggered (create-release-branch.yml)
4. Nightly E2E tests run on weekdays (playwright-nightly.yml)

## Version Selection Rationale

We chose v4 over v5 (the latest) of aws-actions/configure-aws-credentials
because v5 introduced breaking changes in input handling for boolean values.
Since we cannot verify all potential edge cases in our secrets configuration,
we opted for the conservative approach of using v4, which provides all
necessary Node version compatibility while minimizing risk of runtime issues.

Both v4 and v5 use Node 20 internally and are compatible with Node 24 runners.

## Impact

- Ensures CI/CD pipelines remain operational beyond April 2026
- Eliminates technical debt from deprecated Node versions
- Maintains consistency across all GitHub Action workflows
- Improves security posture with updated action versions

Resolves: IGDD-2243

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>