### PR TITLE
IGDD-2774 OAuth2 improvements

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -22,6 +22,9 @@ http {
 
     sendfile on;
 
+    # Used to hide nginx version
+    server_tokens off;
+
     server {
         listen 443 ssl;
         server_name localhost;
@@ -46,6 +49,10 @@ http {
         # OCSP Stapling (turning off, using self signed cert)
         ssl_stapling off;
         ssl_stapling_verify off;
+
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src 'self' https://izgateway1.oktapreview.com https://www.google-analytics.com; img-src 'self' data:;" always;
 
         location / {
             proxy_pass http://localhost:3000;

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -10,9 +10,6 @@ events {}
 http {
     include /etc/nginx/mime.types;
 
-    # Add HSTS header globally
-    add_header Strict-Transport-Security "max-age=63072000" always;
-
     log_format main '$remote_addr - $remote_user [$time_local] "$request" '
                     '$status $body_bytes_sent "$http_referer" '
                     '"$http_user_agent" "$http_x_forwarded_for"';
@@ -28,6 +25,12 @@ http {
     server {
         listen 443 ssl;
         server_name localhost;
+
+        # Add HSTS header - best practice is to place this in the server block
+        add_header Strict-Transport-Security "max-age=63072000" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+
 
         # SSL configuration
         ssl_certificate /etc/nginx/ssl/cert.pem;
@@ -49,9 +52,6 @@ http {
         # OCSP Stapling (turning off, using self signed cert)
         ssl_stapling off;
         ssl_stapling_verify off;
-
-        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
 
         location / {
             proxy_pass http://localhost:3000;

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -52,7 +52,6 @@ http {
 
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src 'self' https://izgateway1.oktapreview.com https://www.google-analytics.com; img-src 'self' data:;" always;
 
         location / {
             proxy_pass http://localhost:3000;

--- a/src/pages/api/api-middleware-helper.ts
+++ b/src/pages/api/api-middleware-helper.ts
@@ -1,6 +1,7 @@
 import { Middleware } from 'next-api-middleware'
 import { authOptions } from './auth/[...nextauth]'
 import { getServerSession } from 'next-auth'
+import { getToken } from 'next-auth/jwt'
 import logger from '../../../logger'
 import hasAccessToDestId from '../../lib/accesshelper'
 import { NextApiHandler, NextApiRequest, NextApiResponse } from 'next'
@@ -126,7 +127,8 @@ const withMiddleware = (...middlewareNames: string[]) => {
         (req.headers['x-forwarded-for'] as string)?.split(',')[0] ||
         req.socket?.remoteAddress ||
         'unknown'
-      const sub = session?.user?.sub || undefined
+      const jwtToken = await getToken({ req })
+      const sub = (jwtToken?.sub as string) || undefined
       const context: Context = { user, ipAddress, sub, session }
       await asyncRequestContext.run(context, async () => {
         const dispatch = async (i: number): Promise<void> => {

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -26,10 +26,7 @@ export const authOptions = {
     async session({ session, token, user }) {
       if (token) {
         session.user.id = token.id
-        session.accessToken = token.accessToken
-        session.user.groups = token.groups
         session.user.role = _.intersection(token.groups, roles)[0]
-        session.user.sub = token.sub
         session.user.isAdmin = token?.groups?.includes(
           process.env.OPERATIONS_GROUP
         )


### PR DESCRIPTION
## OAuth2 Security Review — Summary of Findings and Changes

### Background

The ticket asked us to verify that the OAuth2 workflow (NextAuth.js + Okta) does not expose sensitive data to the browser, since any user can view all client-side network traffic via browser DevTools.

### Investigation

We captured HAR files (browser network traces) during login and normal usage, then analyzed every request/response for sensitive data exposure.

**OAuth2 Flow Verification:** The application correctly implements the **Authorization Code Grant** with Okta:
1. Browser redirects to Okta's domain (`izgateway1.oktapreview.com/oauth2/v1/authorize`)
2. User authenticates on Okta's domain (credentials never touch our server)
3. Okta redirects back with an authorization code
4. NextJS server exchanges the code for tokens **server-side** (not visible in browser traffic)
5. Browser receives only a session cookie

Steps 1-4 are compliant. The problem was in what happened *after* the token exchange.

### Finding: Access Token Leaked to Browser

The NextAuth.js `session` callback was copying the Okta access token, user groups, and Okta subject ID into the session object returned by `GET /api/auth/session`. This endpoint is called by client-side JavaScript, meaning the full Okta access token (a JWT bearer credential valid for ~1 hour) was visible in the browser's network tab.

This effectively negated the security benefit of the Authorization Code Grant — the whole point of that flow is that tokens stay server-side.

### Additional Findings: Missing Security Headers

An audit of the response headers from nginx revealed:
- **Server version disclosure** — `server: nginx/1.28.3` was exposed
- **Missing `Referrer-Policy`** header
- **Missing `Permissions-Policy`** header
- **Missing `Content-Security-Policy`** — we attempted to add a CSP but it blocked the NextAuth built-in signin page (which uses inline styles and loads images from `authjs.dev`). CSP is deferred for now and should be revisited with `'unsafe-inline'` allowances or a nonce-based approach.
- **Note:** Adding `add_header` directives in nginx can silently drop existing headers (like HSTS) due to nginx's inheritance rules — all `add_header` directives must live in the same block.

### Changes Made

**`src/pages/api/auth/[...nextauth].ts`** — Removed sensitive data from the session callback:
- Removed `session.accessToken = token.accessToken` — the access token no longer reaches the browser
- Removed `session.user.groups` — group memberships no longer exposed to client
- Removed `session.user.sub` — Okta user ID no longer exposed to client
- Kept `session.user.role` and `session.user.isAdmin` (derived from groups, needed for UI rendering)

**`src/pages/api/api-middleware-helper.ts`** — Since `sub` was removed from the client session, server-side code that needed it now retrieves it directly from the encrypted JWT token using `getToken({ req })` from `next-auth/jwt`. This keeps `sub` available for server-side logging/context without exposing it to the browser.

**`nginx.conf.template`** — Hardened response headers:
- Added `server_tokens off` in the `http` block to hide the nginx version
- Added `Referrer-Policy: strict-origin-when-cross-origin` in the `server` block
- Added `Permissions-Policy: camera=(), microphone=(), geolocation=()` in the `server` block

### Verification

A post-fix HAR capture confirmed:
- `/api/auth/session` returns only `{ user: { name, email, role, isAdmin }, expires }` — no tokens
- No JWT strings appear in any application response
- `server` header shows `nginx` with no version
- New security headers are present
