### PR TITLE
IGDD-2792: Remove saml2-js dead dependency to resolve xmldom CVEs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,24 @@
+# izg-configuration-console Copilot Instructions
+
+## Runtime Environment
+
+- **Minimum Node.js version: 24.x**
+  - Base image: `ghcr.io/izgateway/alpine-node-openssl-fips:latest` (Alpine 3.23)
+  - Alpine 3.23 ships `nodejs` at **24.x** via `apk add nodejs`
+  - Developer local Node.js: v22.22.2 (lower than base image; test against 24.x for production fidelity)
+  - `globalThis.crypto` is available natively — no polyfill needed for Node 20+ APIs
+
+## Framework
+
+- **Next.js 16 (Pages Router)** — the app uses `src/pages/`, not App Router
+- **next-auth@4** — in maintenance mode; upgrade to v5 requires Pages→App Router migration (separate CR)
+
+## Known CVE Remediation Notes
+
+- **uuid (CVE GHSA-w5hq-g745-h8pq):** `next-auth@4` and `@cypress/request` hold uuid at <14.0.0.
+  The vulnerable functions (`v3/v5/v6` with buffer args) are not called by this app or next-auth.
+  Remediation options: patch-package on next-auth, or local CJS shim for uuid@14.
+  Root fix: upgrade to next-auth@5 (separate CR).
+
+- **@xmldom/xmldom:** `saml2-js` was removed as a dead dependency (2026-04-29) — resolved.
+  Root-level override to `^0.9.10` remains in package.json for any future re-introduction.

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,6 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-to-print": "^2.15.1",
-        "saml2-js": "^4.0.4",
         "swagger-ui-react": "^5.32.5",
         "swr": "^2.4.1",
         "uuid": "^14.0.0",
@@ -4610,54 +4609,6 @@
         "node": ">=12.4.0"
       }
     },
-    "node_modules/@oozcitak/dom": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-2.0.2.tgz",
-      "integrity": "sha512-GjpKhkSYC3Mj4+lfwEyI1dqnsKTgwGy48ytZEhm4A/xnH/8z9M3ZVXKr/YGQi3uCLs1AEBS+x5T2JPiueEDW8w==",
-      "license": "MIT",
-      "dependencies": {
-        "@oozcitak/infra": "^2.0.2",
-        "@oozcitak/url": "^3.0.0",
-        "@oozcitak/util": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=20.0"
-      }
-    },
-    "node_modules/@oozcitak/infra": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@oozcitak/infra/-/infra-2.0.2.tgz",
-      "integrity": "sha512-2g+E7hoE2dgCz/APPOEK5s3rMhJvNxSMBrP+U+j1OWsIbtSpWxxlUjq1lU8RIsFJNYv7NMlnVsCuHcUzJW+8vA==",
-      "license": "MIT",
-      "dependencies": {
-        "@oozcitak/util": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=20.0"
-      }
-    },
-    "node_modules/@oozcitak/url": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@oozcitak/url/-/url-3.0.0.tgz",
-      "integrity": "sha512-ZKfET8Ak1wsLAiLWNfFkZc/BraDccuTJKR6svTYc7sVjbR+Iu0vtXdiDMY4o6jaFl5TW2TlS7jbLl4VovtAJWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@oozcitak/infra": "^2.0.2",
-        "@oozcitak/util": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=20.0"
-      }
-    },
-    "node_modules/@oozcitak/util": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@oozcitak/util/-/util-10.0.0.tgz",
-      "integrity": "sha512-hAX0pT/73190NLqBPPWSdBVGtbY6VOhWYK3qqHqtXQ1gK7kS2yz4+ivsN07hpJ6I3aeMtKP6J6npsEKOAzuTLA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.0"
-      }
-    },
     "node_modules/@panva/hkdf": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
@@ -7036,15 +6987,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@xmldom/is-dom-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@xmldom/is-dom-node/-/is-dom-node-1.0.1.tgz",
-      "integrity": "sha512-CJDxIgE5I0FH+ttq/Fxy6nRpxP70+e2O048EPe85J2use3XKdatVM7dDVvFNjQudd9B49NPoZ+8PG49zj4Er8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      }
     },
     "node_modules/@xmldom/xmldom": {
       "version": "0.9.10",
@@ -9720,12 +9662,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -15519,7 +15455,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -16719,34 +16654,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/saml2-js": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/saml2-js/-/saml2-js-4.0.4.tgz",
-      "integrity": "sha512-HFQvqHhfIkVEzNCjA31/8PRkZ2pauz083E/gH8zriJ8s+RRFbYUa7cwjEdKxiR0Cj8ZV/BnZ+1iIr1zTIGRGsQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@xmldom/xmldom": "^0.8.6",
-        "async": "^3.2.0",
-        "debug": "^4.3.0",
-        "underscore": "^1.8.0",
-        "xml-crypto": "^6.1.2",
-        "xml-encryption": "^3.0.2",
-        "xmlbuilder2": "^2.4.0",
-        "xpath": "^0.0.34"
-      },
-      "engines": {
-        "node": ">=10.x"
-      }
-    },
-    "node_modules/saml2-js/node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/sax": {
       "version": "1.6.0",
@@ -18693,12 +18600,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/underscore": {
-      "version": "1.13.8",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
-      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
-      "license": "MIT"
-    },
     "node_modules/undici": {
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
@@ -19276,67 +19177,6 @@
         "repeat-string": "^1.5.2"
       }
     },
-    "node_modules/xml-crypto": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-6.1.2.tgz",
-      "integrity": "sha512-leBOVQdVi8FvPJrMYoum7Ici9qyxfE4kVi+AkpUoYCSXaQF4IlBm1cneTK9oAxR61LpYxTx7lNcsnBIeRpGW2w==",
-      "license": "MIT",
-      "dependencies": {
-        "@xmldom/is-dom-node": "^1.0.1",
-        "@xmldom/xmldom": "^0.8.10",
-        "xpath": "^0.0.33"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/xml-crypto/node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/xml-crypto/node_modules/xpath": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.33.tgz",
-      "integrity": "sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
-    "node_modules/xml-encryption": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/xml-encryption/-/xml-encryption-3.1.0.tgz",
-      "integrity": "sha512-PV7qnYpoAMXbf1kvQkqMScLeQpjCMixddAKq9PtqVrho8HnYbBOWNfG0kA4R7zxQDo7w9kiYAyzS/ullAyO55Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@xmldom/xmldom": "^0.8.5",
-        "escape-html": "^1.0.3",
-        "xpath": "0.0.32"
-      }
-    },
-    "node_modules/xml-encryption/node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/xml-encryption/node_modules/xpath": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
-      "integrity": "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
     "node_modules/xml-js": {
       "version": "1.6.11",
       "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
@@ -19381,36 +19221,12 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/xmlbuilder2": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-4.0.3.tgz",
-      "integrity": "sha512-bx8Q1STctnNaaDymWnkfQLKofs0mGNN7rLLapJlGuV3VlvegD7Ls4ggMjE3aUSWItCCzU0PEv45lI87iSigiCA==",
-      "license": "MIT",
-      "dependencies": {
-        "@oozcitak/dom": "^2.0.2",
-        "@oozcitak/infra": "^2.0.2",
-        "@oozcitak/util": "^10.0.0",
-        "js-yaml": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=20.0"
-      }
-    },
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/xpath": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.34.tgz",
-      "integrity": "sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.0"
-      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-to-print": "^2.15.1",
-    "saml2-js": "^4.0.4",
     "swagger-ui-react": "^5.32.5",
     "swr": "^2.4.1",
     "uuid": "^14.0.0",


### PR DESCRIPTION
## Summary
Removes saml2-js@4.0.4 which was an unused direct dependency carrying 4 xmldom CVEs.

## CVEs Resolved
- GHSA-2v35-w6hq-6mfw
- GHSA-f6ww-3ggp-fr8h
- GHSA-x6wf-f3px-wcqx
- GHSA-j759-j44w-7fr8

## Root Cause
saml2-js was a dead dependency not imported anywhere in application source.

## Verification
npm audit shows 0 xmldom vulnerabilities after this change.