### PR TITLE
fix: remediate uuid CVE GHSA-w5hq-g745-h8pq

### DIFF
--- a/openspec/changes/uuid-cve-remediation/.openspec.yaml
+++ b/openspec/changes/uuid-cve-remediation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/uuid-cve-remediation/README.md
+++ b/openspec/changes/uuid-cve-remediation/README.md
@@ -1,0 +1,3 @@
+# uuid-cve-remediation
+
+Apply @izgateway/uuid-cjs npm override to resolve uuid CVE GHSA-w5hq-g745-h8pq

--- a/openspec/changes/uuid-cve-remediation/design.md
+++ b/openspec/changes/uuid-cve-remediation/design.md
@@ -1,0 +1,63 @@
+## Context
+
+`izg-configuration-console` uses `next-auth@4`, which internally calls
+`require('uuid')`. The uuid CVE GHSA-w5hq-g745-h8pq requires upgrading uuid to
+≥ 14.0.0, but uuid@12+ is ESM-only — a direct override causes `ERR_REQUIRE_ESM`
+at runtime. The `@izgateway/uuid-cjs` package (CR `uuid-cjs-shim` in
+`IZGateway/uuid-cjs`) is a full CJS replacement for uuid@14 that avoids this
+incompatibility. This CR wires that package in via an npm `overrides` entry.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Clear GHSA-w5hq-g745-h8pq from `npm audit` in `izg-configuration-console`
+- Preserve next-auth v4 login / logout / token-refresh behaviour
+- Zero application code changes
+
+**Non-Goals:**
+- Migrating to next-auth v5 (separate effort requiring App Router migration)
+- Fixing any other CVEs in this CR
+
+## Decisions
+
+### D1 — npm overrides alias syntax
+
+**Decision:** Use `"overrides": { "uuid": "npm:@izgateway/uuid-cjs@^14.0.0" }` in
+`package.json`.
+
+**Rationale:** The `npm:` alias protocol redirects all transitive `require('uuid')`
+calls — including those nested inside `next-auth` — to `@izgateway/uuid-cjs` without
+modifying node_modules manually or forking any dependency. The `^14.0.0` range is
+version-independent: future patch releases of `@izgateway/uuid-cjs` are picked up
+automatically without changing the override.
+
+**Alternatives considered:** Patching next-auth with `patch-package` — rejected
+because patches break silently on upstream version bumps by the automated security
+updater.
+
+## Risks / Trade-offs
+
+**[Risk] @izgateway/uuid-cjs not yet published when this branch is merged**
+→ Merge this branch only after `uuid-cjs-shim` has published `@izgateway/uuid-cjs@14.x`
+to GitHub Packages. CI will fail at `npm install` if the package is unavailable.
+
+**[Risk] .npmrc not configured in CI**
+→ CI must have `NPM_TOKEN` available and `.npmrc` pointing
+`@izgateway:registry=https://npm.pkg.github.com/` for `npm install` to resolve the
+package. Verify the existing CI workflow already handles this; add if missing.
+
+## Migration Plan
+
+1. Confirm `@izgateway/uuid-cjs@14.x` is published to GitHub Packages
+2. Add `overrides` block to `package.json`
+3. Run `npm install`; verify `npm ls uuid` shows all entries resolved to `@izgateway/uuid-cjs`
+4. Run `npm audit`; confirm GHSA-w5hq-g745-h8pq is cleared
+5. Smoke-test login / logout / token refresh locally
+6. Open PR against `develop`; CI must pass
+
+**Rollback:** Remove the `overrides` block. The CVE finding returns but the application
+is otherwise functional.
+
+## Open Questions
+
+_None._

--- a/openspec/changes/uuid-cve-remediation/proposal.md
+++ b/openspec/changes/uuid-cve-remediation/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+As a developer maintaining `izg-configuration-console` (a NextJS / next-auth v4
+application), I need the uuid CVE GHSA-w5hq-g745-h8pq remediated without breaking
+authentication at runtime, so that Federal security compliance requirements are
+satisfied while the longer-term migration to next-auth v5 is planned.
+
+uuid v12+ is ESM-only. next-auth v4 uses `require('uuid')` internally, making a
+direct version override a runtime `ERR_REQUIRE_ESM` crash. The solution is
+`@izgateway/uuid-cjs` — a CJS-compatible full replacement published from the
+`IZGateway/uuid-cjs` repository (see CR `uuid-cjs-shim`). This CR applies the
+npm `overrides` entry that routes all `require('uuid')` calls to that package.
+
+## What Changes
+
+- **`package.json`**: Add `"overrides": { "uuid": "npm:@izgateway/uuid-cjs@^14.0.0" }`
+  so that all transitive `require('uuid')` calls — including those inside next-auth —
+  resolve to `@izgateway/uuid-cjs` instead of the vulnerable uuid@8.3.2.
+- **`package-lock.json`**: Regenerated after `npm install`.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `uuid-override`: npm override wiring that satisfies the uuid CVE without application
+  code changes.
+
+## Impact
+
+- **Security**: Clears GHSA-w5hq-g745-h8pq from `npm audit` in this application.
+- **Runtime**: next-auth v4 JWT signing (login / logout / token refresh) continues to
+  function because `@izgateway/uuid-cjs` exports a CJS-compatible `v4()`.
+- **No code changes**: The override is transparent to all application code.
+- **Dependency**: Requires `@izgateway/uuid-cjs@14.x` to be published to GitHub
+  Packages (CR `uuid-cjs-shim` in `IZGateway/uuid-cjs`).
+
+NOTE: See [uuid-cjs OpenSpec CR proposal](https://github.com/IZGateway/uuid-cjs/blob/main/openspec/changes/uuid-cjs-shim/proposal.md)

--- a/openspec/changes/uuid-cve-remediation/specs/uuid-override.md
+++ b/openspec/changes/uuid-cve-remediation/specs/uuid-override.md
@@ -1,0 +1,56 @@
+# Spec: uuid Override — izg-configuration-console
+
+## ADDED Requirements
+
+### Requirement: npm override routes all uuid requires to @izgateway/uuid-cjs
+
+`package.json` MUST contain an `"overrides"` block that redirects every transitive
+`require('uuid')` call — including those inside `next-auth` — to the
+`@izgateway/uuid-cjs` package at a version compatible with uuid@14.
+
+```json
+"overrides": {
+  "uuid": "npm:@izgateway/uuid-cjs@^14.0.0"
+}
+```
+
+The override MUST use the `npm:` protocol alias syntax so that npm resolves the
+package by its published name without requiring a local path or a fork of next-auth.
+
+#### Scenario: npm ls shows all uuid instances resolved to @izgateway/uuid-cjs
+
+- **WHEN** `npm ls uuid` is run after `npm install`
+- **THEN** every uuid entry in the dependency tree references `@izgateway/uuid-cjs`
+  at version ≥ 14.0.0
+- **AND** no entry references the vulnerable uuid@8.3.2 or any other uuid version
+
+---
+
+### Requirement: npm audit reports no findings for the uuid CVE
+
+After applying the override and running `npm install`, the project MUST be free of
+the uuid CVE finding GHSA-w5hq-g745-h8pq.
+
+#### Scenario: npm audit is clean for the uuid CVE
+
+- **WHEN** `npm audit` is run in `izg-configuration-console`
+- **THEN** no finding referencing GHSA-w5hq-g745-h8pq is reported
+
+---
+
+### Requirement: next-auth authentication continues to function
+
+Overriding uuid MUST NOT break next-auth v4 JWT signing. Login, logout, and token
+refresh MUST continue to work correctly after the override is applied, because
+`@izgateway/uuid-cjs` exports a CJS-compatible `v4()` function that next-auth calls
+internally.
+
+#### Scenario: Login succeeds after override
+
+- **WHEN** a user attempts to log in via next-auth
+- **THEN** the login succeeds and a session is established without a runtime error
+
+#### Scenario: Token refresh succeeds after override
+
+- **WHEN** next-auth refreshes a JWT token
+- **THEN** the refresh completes without an `ERR_REQUIRE_ESM` or other runtime error

--- a/openspec/changes/uuid-cve-remediation/tasks.md
+++ b/openspec/changes/uuid-cve-remediation/tasks.md
@@ -1,0 +1,19 @@
+## 1. Prerequisite Check
+
+- [ ] 1.1 Confirm `@izgateway/uuid-cjs@14.x` is published and installable from GitHub Packages
+
+## 2. Apply Override
+
+- [ ] 2.1 Add `"overrides": { "uuid": "npm:@izgateway/uuid-cjs@^14.0.0" }` to `package.json`
+- [ ] 2.2 Run `npm install` and confirm it completes without error
+- [ ] 2.3 Run `npm ls uuid` and verify every uuid entry resolves to `@izgateway/uuid-cjs@14.x`
+- [ ] 2.4 Run `npm audit` and confirm zero findings for GHSA-w5hq-g745-h8pq
+
+## 3. Verify Functionality
+
+- [ ] 3.1 Smoke-test login, logout, and token refresh locally — confirm no `ERR_REQUIRE_ESM` or auth errors
+
+## 4. Merge
+
+- [ ] 4.1 Commit `package.json` and `package-lock.json` changes
+- [ ] 4.2 Open PR against `develop`; verify CI passes

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
         "saml2-js": "^4.0.4",
         "swagger-ui-react": "^5.32.5",
         "swr": "^2.4.1",
-        "uuid": "^14.0.0",
         "waait": "^1.0.5",
         "winston": "^3.19.0",
         "xml-js": "^1.6.11",
@@ -2255,16 +2254,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/@cypress/request/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@cypress/xvfb": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@cypress/xvfb/-/xvfb-1.2.4.tgz",
@@ -2321,14 +2310,14 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
@@ -2343,9 +2332,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3005,6 +2994,9 @@
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3020,6 +3012,9 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3037,6 +3032,9 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3052,6 +3050,9 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3069,6 +3070,9 @@
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3084,6 +3088,9 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3101,6 +3108,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3117,6 +3127,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3132,6 +3145,9 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3155,6 +3171,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3176,6 +3195,9 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3199,6 +3221,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3220,6 +3245,9 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3243,6 +3271,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3265,6 +3296,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3286,6 +3320,9 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -4461,6 +4498,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4476,6 +4516,9 @@
       "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4493,6 +4536,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4508,6 +4554,9 @@
       "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6874,6 +6923,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6888,6 +6940,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6902,6 +6957,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6916,6 +6974,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6930,6 +6991,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6944,6 +7008,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6958,6 +7025,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6972,6 +7042,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14596,15 +14669,6 @@
         }
       }
     },
-    "node_modules/next-auth/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/next-swagger-doc": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/next-swagger-doc/-/next-swagger-doc-0.4.1.tgz",
@@ -15519,7 +15583,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -18844,16 +18907,13 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
+      "name": "@izgateway/uuid-cjs",
+      "version": "14.0.6",
+      "resolved": "https://npm.pkg.github.com/download/@izgateway/uuid-cjs/14.0.6/944bcde8099ab62e8a35d141b29e844abfa1d26e",
+      "integrity": "sha512-GBSFLPehb2mJMSrDs+4YXHqUmLRB7V0Qkd5HhI8O7HMetnChBB+POxgXXrorVAtgv+LuHXBvJNly8Mj4Zi4zPQ==",
       "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18908,9 +18908,9 @@
     },
     "node_modules/uuid": {
       "name": "@izgateway/uuid-cjs",
-      "version": "14.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@izgateway/uuid-cjs/14.0.6/944bcde8099ab62e8a35d141b29e844abfa1d26e",
-      "integrity": "sha512-GBSFLPehb2mJMSrDs+4YXHqUmLRB7V0Qkd5HhI8O7HMetnChBB+POxgXXrorVAtgv+LuHXBvJNly8Mj4Zi4zPQ==",
+      "version": "14.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@izgateway/uuid-cjs/14.0.7/54a4030f969f58ac04bc5de0b458c2df6eabc4b6",
+      "integrity": "sha512-PVHvblhAQkSXrCHnj8ImIgWSFRVIhIsSpUbw/UY0xDhaSJW54gcrsVaLlW9PUytXK5ghtHehoqfe87szINnyRQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "saml2-js": "^4.0.4",
     "swagger-ui-react": "^5.32.5",
     "swr": "^2.4.1",
-    "uuid": "^14.0.0",
     "waait": "^1.0.5",
     "winston": "^3.19.0",
     "xml-js": "^1.6.11",
@@ -133,6 +132,7 @@
       "immutable": "^4.3.8"
     },
     "underscore": "^1.13.8",
+    "uuid": "npm:@izgateway/uuid-cjs@^14.0.0",
     "xmlbuilder2": "^4.0.3"
   }
 }


### PR DESCRIPTION
Remediates GHSA-w5hq-g745-h8pq by redirecting transitive uuid deps to @izgateway/uuid-cjs@14.0.6 via npm overrides. Closes IGDD-2793.