### PR TITLE
chore(deps): security and dependency updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "izg-configuration-console",
       "version": "1.13.0",
       "dependencies": {
-        "@aws-sdk/client-dynamodb": "^3.1043.0",
-        "@aws-sdk/client-secrets-manager": "^3.1043.0",
-        "@aws-sdk/lib-dynamodb": "^3.1043.0",
+        "@aws-sdk/client-dynamodb": "^3.1045.0",
+        "@aws-sdk/client-secrets-manager": "^3.1045.0",
+        "@aws-sdk/lib-dynamodb": "^3.1045.0",
         "@axe-core/react": "^4.11.3",
         "@babel/types": "^7.29.0",
         "@elastic/ecs-winston-format": "^1.5.3",
@@ -25,7 +25,7 @@
         "@mui/material": "^5.18.0",
         "@mui/x-data-grid": "7.29.13",
         "@mui/x-date-pickers": "^6.20.2",
-        "@types/node": "^20.19.39",
+        "@types/node": "^20.19.40",
         "@types/node-fetch": "^2.6.13",
         "@types/tcp-ping": "^0.1.6",
         "@types/xml2js": "^0.4.14",
@@ -37,7 +37,7 @@
         "lodash": "^4.18.1",
         "moment": "^2.30.1",
         "moment-timezone": "^0.6.2",
-        "next": "^16.2.4",
+        "next": "^16.2.6",
         "next-api-middleware": "^3.0.0",
         "next-auth": "^4.24.14",
         "next-swagger-doc": "^0.4.1",
@@ -57,7 +57,7 @@
         "@commitlint/cli": "^17.8.1",
         "@commitlint/config-conventional": "^17.8.1",
         "@izgateway/dependency-scripts": "^1.0.1",
-        "@next/eslint-plugin-next": "^16.2.4",
+        "@next/eslint-plugin-next": "^16.2.6",
         "@playwright/test": "^1.59.1",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^14.3.1",
@@ -72,7 +72,7 @@
         "cross-env": "^7.0.3",
         "cypress": "^14.5.4",
         "dotenv": "^16.6.1",
-        "eslint-config-next": "^16.2.4",
+        "eslint-config-next": "^16.2.6",
         "eslint-config-prettier": "^8.10.2",
         "husky": "^8.0.3",
         "jest": "^29.7.0",
@@ -330,9 +330,9 @@
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.1043.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1043.0.tgz",
-      "integrity": "sha512-xKZFIjBA1AbyMYPAfcslBypcI9n8Ga3N2dSiuzX3OHdmG3TXAmhiAEV9reoi/4lI3HXW3dV94OizOAcPEbsWAA==",
+      "version": "3.1045.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1045.0.tgz",
+      "integrity": "sha512-TxZmhpziFxWD3pdXGbuwntKOX5OkW14yvCITYsRz+QDM5EUL4cIygu2xRGHiKDvKmb3QUOA4yKetAQcIMLe2zw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -383,9 +383,9 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1043.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1043.0.tgz",
-      "integrity": "sha512-xjxE4CSid16j9yBFuykNinW7z+RwqJGxqCDD+hh99jL6YRmVa6FZOkv96gur5jHfrolbb0e19aS3ztD7UWmcLQ==",
+      "version": "3.1045.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1045.0.tgz",
+      "integrity": "sha512-ceXmaTE/3j7bHgVzUrpL/ECjQQ+aE/x8wNbblC/SIb020OxYRMj0DscFimnI5kEjutGHQ+A68bbX2A+bZuAMEA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -645,9 +645,9 @@
       }
     },
     "node_modules/@aws-sdk/lib-dynamodb": {
-      "version": "3.1043.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1043.0.tgz",
-      "integrity": "sha512-BbMY8HuAfY9F/kWYMVzY3pWMti9J1ZhX3WRLTaHsMOgyXAtz+Cs+1uPYYlri8J07xrDM22jMrBhqJgAa0ZnFVg==",
+      "version": "3.1045.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1045.0.tgz",
+      "integrity": "sha512-U8PWWu3MGrsivZz8xMuRFnaP7ir9r/GvYRcrFRek8FhndiqB8OPQTCA2e+ki+ApLuPjj1foUs+3arTVptt1QGQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.8",
@@ -661,7 +661,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-dynamodb": "^3.1043.0"
+        "@aws-sdk/client-dynamodb": "^3.1045.0"
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
@@ -854,9 +854,9 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1043.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1043.0.tgz",
-      "integrity": "sha512-Rlh9piVFV4WOMGgcHY0+O4TMDOSJGYxh7dvxWIhmhf6ASvRPMA2HZb6DSCan8nl5IFXjCYxYXWjpb5+Ii77MjQ==",
+      "version": "3.1045.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1045.0.tgz",
+      "integrity": "sha512-/o4qcty0DmQola0DBniRVeBakYY6ALOvKEFo1AtJpTmMn/cJ+Fk3RWGe5ieT/f/eYbHG9k5E7poKge/E+WGv4Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.8",
@@ -989,6 +989,27 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder/node_modules/fast-xml-parser": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@aws/lambda-invoke-store": {
@@ -4395,15 +4416,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
-      "integrity": "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
+      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.4.tgz",
-      "integrity": "sha512-tOX826JJ96gYK/go18sPUgMq9FK1tqxBFfUCEufJb5XIkWFFmpgU7mahJANKGkHs7F41ir3tReJ3Lv5La0RvhA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.6.tgz",
+      "integrity": "sha512-Z8l6o4JWKUl755x4R+wogD86KPeU+Ckw4K+SYG4kHeOJtRenDeK+OSbGcqZpDtbwn9DsJVdir2UxmwXuinUbUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4411,9 +4432,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz",
-      "integrity": "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
+      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
       "cpu": [
         "arm64"
       ],
@@ -4427,9 +4448,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
-      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
+      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
       "cpu": [
         "x64"
       ],
@@ -4443,9 +4464,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
-      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
+      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
       "cpu": [
         "arm64"
       ],
@@ -4459,9 +4480,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
-      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
+      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
       "cpu": [
         "arm64"
       ],
@@ -4475,9 +4496,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
-      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
+      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
       "cpu": [
         "x64"
       ],
@@ -4491,9 +4512,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
-      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
+      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
       "cpu": [
         "x64"
       ],
@@ -4507,9 +4528,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
-      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
+      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
       "cpu": [
         "arm64"
       ],
@@ -4523,9 +4544,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
-      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
+      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
       "cpu": [
         "x64"
       ],
@@ -6268,9 +6289,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "version": "20.19.40",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.40.tgz",
+      "integrity": "sha512-xxx6M2IpSTnnKcR0cMvIiohkiCx20/oRPtWGbenFygKCGl3zqUzdNjQ/1V4solq1LU+dgv0nQzeGOuqkqZGg0Q==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -9726,13 +9747,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.4.tgz",
-      "integrity": "sha512-A6ekXYFj/YQxBPMl45g3e+U8zJo+X2+ZQwcz34pPKjpc/3S4roBA2Rd9xWB4FKuSxhofo1/95WjzmUY+wHrOhg==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.6.tgz",
+      "integrity": "sha512-z2ELYSkyrrJ6cuunTU8vhsT/RpouPkjaSah06nVW6Rg2Hpg0Vs8s497/e5s8G8qtdp4ccsiovz5P1rv+5VSW2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "16.2.4",
+        "@next/eslint-plugin-next": "16.2.6",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.32.0",
@@ -10522,27 +10543,6 @@
       "license": "MIT",
       "dependencies": {
         "path-expression-matcher": "^1.1.3"
-      }
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
-      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.7",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/fastq": {
@@ -14368,9 +14368,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -14425,12 +14425,12 @@
       }
     },
     "node_modules/next": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
-      "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
+      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.4",
+        "@next/env": "16.2.6",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -14444,14 +14444,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.4",
-        "@next/swc-darwin-x64": "16.2.4",
-        "@next/swc-linux-arm64-gnu": "16.2.4",
-        "@next/swc-linux-arm64-musl": "16.2.4",
-        "@next/swc-linux-x64-gnu": "16.2.4",
-        "@next/swc-linux-x64-musl": "16.2.4",
-        "@next/swc-win32-arm64-msvc": "16.2.4",
-        "@next/swc-win32-x64-msvc": "16.2.4",
+        "@next/swc-darwin-arm64": "16.2.6",
+        "@next/swc-darwin-x64": "16.2.6",
+        "@next/swc-linux-arm64-gnu": "16.2.6",
+        "@next/swc-linux-arm64-musl": "16.2.6",
+        "@next/swc-linux-x64-gnu": "16.2.6",
+        "@next/swc-linux-x64-musl": "16.2.6",
+        "@next/swc-win32-arm64-msvc": "16.2.6",
+        "@next/swc-win32-x64-msvc": "16.2.6",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {
@@ -15456,9 +15456,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -15475,9 +15475,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "test:dev": "cross-env BASE_URL=https://dev.console.izgateway.org npx playwright test --project=Chrome --headed"
   },
   "dependencies": {
-    "@aws-sdk/client-dynamodb": "^3.1043.0",
-    "@aws-sdk/client-secrets-manager": "^3.1043.0",
-    "@aws-sdk/lib-dynamodb": "^3.1043.0",
+    "@aws-sdk/client-dynamodb": "^3.1045.0",
+    "@aws-sdk/client-secrets-manager": "^3.1045.0",
+    "@aws-sdk/lib-dynamodb": "^3.1045.0",
     "@axe-core/react": "^4.11.3",
     "@babel/types": "^7.29.0",
     "@elastic/ecs-winston-format": "^1.5.3",
@@ -36,7 +36,7 @@
     "@mui/material": "^5.18.0",
     "@mui/x-data-grid": "7.29.13",
     "@mui/x-date-pickers": "^6.20.2",
-    "@types/node": "^20.19.39",
+    "@types/node": "^20.19.40",
     "@types/node-fetch": "^2.6.13",
     "@types/tcp-ping": "^0.1.6",
     "@types/xml2js": "^0.4.14",
@@ -48,7 +48,7 @@
     "lodash": "^4.18.1",
     "moment": "^2.30.1",
     "moment-timezone": "^0.6.2",
-    "next": "^16.2.4",
+    "next": "^16.2.6",
     "next-api-middleware": "^3.0.0",
     "next-auth": "^4.24.14",
     "next-swagger-doc": "^0.4.1",
@@ -68,7 +68,7 @@
     "@commitlint/cli": "^17.8.1",
     "@commitlint/config-conventional": "^17.8.1",
     "@izgateway/dependency-scripts": "^1.0.1",
-    "@next/eslint-plugin-next": "^16.2.4",
+    "@next/eslint-plugin-next": "^16.2.6",
     "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^14.3.1",
@@ -83,7 +83,7 @@
     "cross-env": "^7.0.3",
     "cypress": "^14.5.4",
     "dotenv": "^16.6.1",
-    "eslint-config-next": "^16.2.4",
+    "eslint-config-next": "^16.2.6",
     "eslint-config-prettier": "^8.10.2",
     "husky": "^8.0.3",
     "jest": "^29.7.0",
@@ -99,22 +99,7 @@
     "typescript": "^5.9.3"
   },
   "overrides": {
-    "@aws-sdk/core": "3.974.8",
-    "@aws-sdk/credential-provider-env": "3.972.34",
-    "@aws-sdk/credential-provider-http": "3.972.36",
-    "@aws-sdk/credential-provider-ini": "3.972.38",
-    "@aws-sdk/credential-provider-login": "3.972.38",
-    "@aws-sdk/credential-provider-node": "3.972.39",
-    "@aws-sdk/credential-provider-process": "3.972.34",
-    "@aws-sdk/credential-provider-sso": "3.972.38",
-    "@aws-sdk/credential-provider-web-identity": "3.972.38",
-    "@aws-sdk/dynamodb-codec": "3.973.8",
-    "@aws-sdk/middleware-sdk-s3": "3.972.37",
-    "@aws-sdk/middleware-user-agent": "3.972.38",
-    "@aws-sdk/nested-clients": "3.997.6",
-    "@aws-sdk/signature-v4-multi-region": "3.996.25",
-    "@aws-sdk/token-providers": "3.1043.0",
-    "@aws-sdk/util-user-agent-node": "3.973.24",
+    "@aws-sdk/token-providers": "3.1045.0",
     "@eslint/eslintrc": {
       "ajv": "^6.14.0"
     },
@@ -122,11 +107,9 @@
     "eslint": {
       "ajv": "^6.14.0"
     },
-    "fast-xml-parser": "5.7.3",
     "http-proxy-agent": "^7.0.2",
     "js-yaml": "^4.1.1",
     "jsdom": "^28.1.0",
-    "postcss": "8.5.14",
     "swagger-ui-react": {
       "immutable": "^4.3.8"
     },


### PR DESCRIPTION
# Security and Dependency Update Summary

## 🔒 Automated Security & Dependency Updates

This PR updates dependencies to their latest **minor versions** and addresses security vulnerabilities at all severity levels.

### Changes Made:
- ✅ Updated dependencies to latest compatible minor versions
- ✅ Fixed all vulnerabilities (updated direct deps + added overrides)
- ✅ Removed unnecessary overrides (where all resolved versions meet requirements)
- ✅ Updated `package-lock.json`
- ✅ Ran linting, type-checking, and tests
- ✅ Built application successfully

### Package Changes:
```diff
diff --git a/package.json b/package.json
index 8756837..eca1084 100644
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "test:dev": "cross-env BASE_URL=https://dev.console.izgateway.org npx playwright test --project=Chrome --headed"
   },
   "dependencies": {
-    "@aws-sdk/client-dynamodb": "^3.1043.0",
-    "@aws-sdk/client-secrets-manager": "^3.1043.0",
-    "@aws-sdk/lib-dynamodb": "^3.1043.0",
+    "@aws-sdk/client-dynamodb": "^3.1045.0",
+    "@aws-sdk/client-secrets-manager": "^3.1045.0",
+    "@aws-sdk/lib-dynamodb": "^3.1045.0",
     "@axe-core/react": "^4.11.3",
     "@babel/types": "^7.29.0",
     "@elastic/ecs-winston-format": "^1.5.3",
@@ -36,7 +36,7 @@
     "@mui/material": "^5.18.0",
     "@mui/x-data-grid": "7.29.13",
     "@mui/x-date-pickers": "^6.20.2",
-    "@types/node": "^20.19.39",
+    "@types/node": "^20.19.40",
     "@types/node-fetch": "^2.6.13",
     "@types/tcp-ping": "^0.1.6",
     "@types/xml2js": "^0.4.14",
@@ -48,7 +48,7 @@
     "lodash": "^4.18.1",
     "moment": "^2.30.1",
     "moment-timezone": "^0.6.2",
-    "next": "^16.2.4",
+    "next": "^16.2.6",
     "next-api-middleware": "^3.0.0",
     "next-auth": "^4.24.14",
     "next-swagger-doc": "^0.4.1",
@@ -68,7 +68,7 @@
     "@commitlint/cli": "^17.8.1",
     "@commitlint/config-conventional": "^17.8.1",
     "@izgateway/dependency-scripts": "^1.0.1",
-    "@next/eslint-plugin-next": "^16.2.4",
+    "@next/eslint-plugin-next": "^16.2.6",
     "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^14.3.1",
@@ -83,7 +83,7 @@
     "cross-env": "^7.0.3",
     "cypress": "^14.5.4",
     "dotenv": "^16.6.1",
-    "eslint-config-next": "^16.2.4",
+    "eslint-config-next": "^16.2.6",
     "eslint-config-prettier": "^8.10.2",
     "husky": "^8.0.3",
     "jest": "^29.7.0",
@@ -99,22 +99,7 @@
     "typescript": "^5.9.3"
   },
   "overrides": {
-    "@aws-sdk/core": "3.974.8",
-    "@aws-sdk/credential-provider-env": "3.972.34",
-    "@aws-sdk/credential-provider-http": "3.972.36",
-    "@aws-sdk/credential-provider-ini": "3.972.38",
-    "@aws-sdk/credential-provider-login": "3.972.38",
-    "@aws-sdk/credential-provider-node": "3.972.39",
-    "@aws-sdk/credential-provider-process": "3.972.34",
-    "@aws-sdk/credential-provider-sso": "3.972.38",
-    "@aws-sdk/credential-provider-web-identity": "3.972.38",
-    "@aws-sdk/dynamodb-codec": "3.973.8",
-    "@aws-sdk/middleware-sdk-s3": "3.972.37",
-    "@aws-sdk/middleware-user-agent": "3.972.38",
-    "@aws-sdk/nested-clients": "3.997.6",
-    "@aws-sdk/signature-v4-multi-region": "3.996.25",
-    "@aws-sdk/token-providers": "3.1043.0",
-    "@aws-sdk/util-user-agent-node": "3.973.24",
+    "@aws-sdk/token-providers": "3.1045.0",
     "@eslint/eslintrc": {
       "ajv": "^6.14.0"
     },
@@ -122,11 +107,9 @@
     "eslint": {
       "ajv": "^6.14.0"
     },
-    "fast-xml-parser": "5.7.3",
     "http-proxy-agent": "^7.0.2",
     "js-yaml": "^4.1.1",
     "jsdom": "^28.1.0",
-    "postcss": "8.5.14",
     "swagger-ui-react": {
       "immutable": "^4.3.8"
     },
```

### Review Checklist:
- [ ] Review version changes in `package.json`
- [ ] Verify no breaking changes in release notes
- [ ] Check that all tests pass
- [ ] Confirm security audit results
- [ ] Test locally if needed

---
**Generated:** 2026-05-08 04:04:23 UTC
**Workflow Run:** [25535971229](https://github.com/IZGateway/izg-configuration-console/actions/runs/25535971229)