### PR TITLE
IGDD-2272 - Split Circuit Breaker & Database Refresh buttons by environment

### DIFF
--- a/src/components/AdminOperations/CircuitBreakerCard.tsx
+++ b/src/components/AdminOperations/CircuitBreakerCard.tsx
@@ -2,43 +2,75 @@ import * as React from 'react'
 import { Box, Typography, Button, Card, CardContent, Divider } from '@mui/material'
 import ResetCircuitBreakerDialog from './ResetCircuitBreakerDialog'
 import Loader from '../Loader'
+import type { CircuitBreakerResetEnvironment } from '../../lib/utils/izghubcircuitbreakerreset'
 
 interface CircuitBreakerCardProps {
+  environments: CircuitBreakerResetEnvironment[]
   onResult: (result: { level: 'success' | 'error'; message: string }) => void
 }
 
-const CircuitBreakerCard = ({ onResult }: CircuitBreakerCardProps) => {
+const getButtonId = (environment: CircuitBreakerResetEnvironment) =>
+  `reset-${environment.destinationType.toLowerCase()}-circuit-breakers`
+
+const CircuitBreakerCard = ({
+  environments,
+  onResult,
+}: CircuitBreakerCardProps) => {
   const [confirmOpen, setConfirmOpen] = React.useState(false)
+  const [selectedEnvironment, setSelectedEnvironment] =
+    React.useState<CircuitBreakerResetEnvironment | null>(null)
   const [loading, setLoading] = React.useState(false)
 
   const handleReset = async () => {
+    const environment = selectedEnvironment
+
+    if (!environment) {
+      return
+    }
+
     setLoading(true)
     try {
       const res = await fetch('/api/status/reset', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          destinationTypeId: environment.destinationTypeId,
+        }),
       })
       const data = await res.json()
       if (res.ok) {
         onResult({
           level: 'success',
-          message: 'All circuit breakers were reset.',
+          message: `${environment.label} circuit breakers were reset.`,
         })
       } else {
         onResult({
           level: 'error',
-          message: data.error || 'Failed to reset circuit breakers.',
+          message: `Failed to reset ${environment.label} circuit breakers. ${
+            data.error || 'Please try again.'
+          }`,
         })
       }
     } catch {
       onResult({
         level: 'error',
-        message: 'Failed to reset circuit breakers. Please try again.',
+        message: `Failed to reset ${environment.label} circuit breakers. Please try again.`,
       })
     } finally {
       setLoading(false)
       setConfirmOpen(false)
+      setSelectedEnvironment(null)
     }
+  }
+
+  const openConfirmDialog = (environment: CircuitBreakerResetEnvironment) => {
+    setSelectedEnvironment(environment)
+    setConfirmOpen(true)
+  }
+
+  const closeConfirmDialog = () => {
+    setConfirmOpen(false)
+    setSelectedEnvironment(null)
   }
 
   return (
@@ -52,35 +84,42 @@ const CircuitBreakerCard = ({ onResult }: CircuitBreakerCardProps) => {
         </Typography>
         <Divider sx={{ my: 2 }} />
         <Typography paragraph>
-          Reset circuit breakers globally to recover from connection failures.
-          When a circuit breaker is thrown, the affected destination becomes
-          unreachable until manually reset. Resetting signals every hub instance
-          across all environments to restore connectivity; the updated status
-          reflects once the operation completes.
+          Reset circuit breakers to recover from connection failures. When a
+          circuit breaker is thrown, the affected destination becomes
+          unreachable until manually reset. Use the controls below to reset the
+          circuit breakers for a connected Hub environment.
         </Typography>
-        <Box sx={{ display: 'flex', gap: 2, mt: 2 }}>
-          <Button
-            id="reset-all-circuit-breakers"
-            variant="contained"
-            color="primary"
-            size="large"
-            disabled={loading}
-            onClick={() => setConfirmOpen(true)}
-            sx={{ borderRadius: 6, textTransform: 'uppercase' }}
-          >
-            Reset All Circuit Breakers
-          </Button>
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mt: 2 }}>
+          {environments.map((environment) => (
+            <Button
+              key={environment.destinationTypeId}
+              id={getButtonId(environment)}
+              variant="contained"
+              color="primary"
+              size="large"
+              disabled={loading}
+              onClick={() => openConfirmDialog(environment)}
+              sx={{ borderRadius: 6, textTransform: 'uppercase' }}
+            >
+              Reset {environment.label}
+            </Button>
+          ))}
+          {environments.length === 0 && (
+            <Typography color="text.secondary">
+              No Hub environments are configured for circuit breaker reset.
+            </Typography>
+          )}
         </Box>
         <Loader open={loading} />
       </CardContent>
 
-      {confirmOpen && (
+      {confirmOpen && selectedEnvironment && (
         <ResetCircuitBreakerDialog
           open={confirmOpen}
-          target="all destinations across every Hub environment"
+          target={`the ${selectedEnvironment.label} environment`}
           loading={loading}
           onConfirm={handleReset}
-          onCancel={() => setConfirmOpen(false)}
+          onCancel={closeConfirmDialog}
         />
       )}
     </Card>

--- a/src/components/AdminOperations/CircuitBreakerCard.tsx
+++ b/src/components/AdminOperations/CircuitBreakerCard.tsx
@@ -2,14 +2,14 @@ import * as React from 'react'
 import { Box, Typography, Button, Card, CardContent, Divider } from '@mui/material'
 import ResetCircuitBreakerDialog from './ResetCircuitBreakerDialog'
 import Loader from '../Loader'
-import type { CircuitBreakerResetEnvironment } from '../../lib/utils/izghubcircuitbreakerreset'
+import type { HubEnvironment } from '../../lib/utils/izghubenvironments'
 
 interface CircuitBreakerCardProps {
-  environments: CircuitBreakerResetEnvironment[]
+  environments: HubEnvironment[]
   onResult: (result: { level: 'success' | 'error'; message: string }) => void
 }
 
-const getButtonId = (environment: CircuitBreakerResetEnvironment) =>
+const getButtonId = (environment: HubEnvironment) =>
   `reset-${environment.destinationType.toLowerCase()}-circuit-breakers`
 
 const CircuitBreakerCard = ({
@@ -18,7 +18,7 @@ const CircuitBreakerCard = ({
 }: CircuitBreakerCardProps) => {
   const [confirmOpen, setConfirmOpen] = React.useState(false)
   const [selectedEnvironment, setSelectedEnvironment] =
-    React.useState<CircuitBreakerResetEnvironment | null>(null)
+    React.useState<HubEnvironment | null>(null)
   const [loading, setLoading] = React.useState(false)
 
   const handleReset = async () => {
@@ -63,7 +63,7 @@ const CircuitBreakerCard = ({
     }
   }
 
-  const openConfirmDialog = (environment: CircuitBreakerResetEnvironment) => {
+  const openConfirmDialog = (environment: HubEnvironment) => {
     setSelectedEnvironment(environment)
     setConfirmOpen(true)
   }

--- a/src/components/AdminOperations/DatabaseRefreshCard.tsx
+++ b/src/components/AdminOperations/DatabaseRefreshCard.tsx
@@ -2,43 +2,75 @@ import * as React from 'react'
 import { Box, Typography, Button, Card, CardContent, Divider } from '@mui/material'
 import ConfirmActionDialog from './ConfirmActionDialog'
 import Loader from '../Loader'
+import type { HubEnvironment } from '../../lib/utils/izghubenvironments'
 
 interface DatabaseRefreshCardProps {
+  environments: HubEnvironment[]
   onResult: (result: { level: 'success' | 'error'; message: string }) => void
 }
 
-const DatabaseRefreshCard = ({ onResult }: DatabaseRefreshCardProps) => {
+const getButtonId = (environment: HubEnvironment) =>
+  `refresh-${environment.destinationType.toLowerCase()}-database`
+
+const DatabaseRefreshCard = ({
+  environments,
+  onResult,
+}: DatabaseRefreshCardProps) => {
   const [confirmOpen, setConfirmOpen] = React.useState(false)
+  const [selectedEnvironment, setSelectedEnvironment] =
+    React.useState<HubEnvironment | null>(null)
   const [loading, setLoading] = React.useState(false)
 
   const handleRefresh = async () => {
+    const environment = selectedEnvironment
+
+    if (!environment) {
+      return
+    }
+
     setLoading(true)
     try {
       const res = await fetch('/api/status/refresh', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          destinationTypeId: environment.destinationTypeId,
+        }),
       })
       const data = await res.json()
       if (res.ok) {
         onResult({
           level: 'success',
-          message: 'Database refresh signaled to all hubs.',
+          message: `${environment.label} database refresh was signaled.`,
         })
       } else {
         onResult({
           level: 'error',
-          message: data.error || 'Failed to refresh the database.',
+          message: `Failed to signal ${environment.label} database refresh. ${
+            data.error || 'Please try again.'
+          }`,
         })
       }
     } catch {
       onResult({
         level: 'error',
-        message: 'Failed to refresh the database. Please try again.',
+        message: `Failed to signal ${environment.label} database refresh. Please try again.`,
       })
     } finally {
       setLoading(false)
       setConfirmOpen(false)
+      setSelectedEnvironment(null)
     }
+  }
+
+  const openConfirmDialog = (environment: HubEnvironment) => {
+    setSelectedEnvironment(environment)
+    setConfirmOpen(true)
+  }
+
+  const closeConfirmDialog = () => {
+    setConfirmOpen(false)
+    setSelectedEnvironment(null)
   }
 
   return (
@@ -52,35 +84,42 @@ const DatabaseRefreshCard = ({ onResult }: DatabaseRefreshCardProps) => {
         </Typography>
         <Divider sx={{ my: 2 }} />
         <Typography paragraph>
-          Signal every hub instance across all environments to reload its
-          configuration from the database, so recent changes take effect without
-          a service restart.
+          Signal a connected Hub environment to reload its configuration from
+          the database, so recent changes take effect without a service restart.
         </Typography>
-        <Box sx={{ display: 'flex', gap: 2, mt: 2 }}>
-          <Button
-            id="refresh-database"
-            variant="contained"
-            color="primary"
-            size="large"
-            disabled={loading}
-            onClick={() => setConfirmOpen(true)}
-            sx={{ borderRadius: 6, textTransform: 'uppercase' }}
-          >
-            Refresh Database
-          </Button>
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mt: 2 }}>
+          {environments.map((environment) => (
+            <Button
+              key={environment.destinationTypeId}
+              id={getButtonId(environment)}
+              variant="contained"
+              color="primary"
+              size="large"
+              disabled={loading}
+              onClick={() => openConfirmDialog(environment)}
+              sx={{ borderRadius: 6, textTransform: 'uppercase' }}
+            >
+              Refresh {environment.label}
+            </Button>
+          ))}
+          {environments.length === 0 && (
+            <Typography color="text.secondary">
+              No Hub environments are configured for database refresh.
+            </Typography>
+          )}
         </Box>
         <Loader open={loading} />
       </CardContent>
 
-      {confirmOpen && (
+      {confirmOpen && selectedEnvironment && (
         <ConfirmActionDialog
           open={confirmOpen}
           title="Refresh Database"
-          message="Are you sure you want to signal all hubs to reload their configuration from the database? This action will be logged."
+          message={`Are you sure you want to signal the ${selectedEnvironment.label} hub to reload its configuration from the database? This action will be logged.`}
           confirmLabel="Confirm"
           loading={loading}
           onConfirm={handleRefresh}
-          onCancel={() => setConfirmOpen(false)}
+          onCancel={closeConfirmDialog}
         />
       )}
     </Card>

--- a/src/components/AdminOperations/index.tsx
+++ b/src/components/AdminOperations/index.tsx
@@ -7,9 +7,11 @@ import PasswordEncryptionCard from './PasswordEncryptionCard'
 import CircuitBreakerCard from './CircuitBreakerCard'
 import DatabaseRefreshCard from './DatabaseRefreshCard'
 import InfoPanel from './InfoPanel'
+import type { CircuitBreakerResetEnvironment } from '../../lib/utils/izghubcircuitbreakerreset'
 
 interface AdminOperationsProps {
   hasKeyName: boolean
+  circuitBreakerResetEnvironments: CircuitBreakerResetEnvironment[]
 }
 
 // Two-column responsive grid: operation card on the left, info panel on the right.
@@ -20,7 +22,10 @@ const rowSx = {
   mb: 4,
 } as const
 
-const AdminOperations = ({ hasKeyName }: AdminOperationsProps) => {
+const AdminOperations = ({
+  hasKeyName,
+  circuitBreakerResetEnvironments,
+}: AdminOperationsProps) => {
   const { setAlert, alert } = React.useContext(CombinedContext)
   const [showSnackbar, setShowSnackbar] = React.useState(false)
 
@@ -68,7 +73,10 @@ const AdminOperations = ({ hasKeyName }: AdminOperationsProps) => {
 
       {/* Circuit Breaker Reset */}
       <Box sx={{ mb: 4 }}>
-        <CircuitBreakerCard onResult={handleResult} />
+        <CircuitBreakerCard
+          environments={circuitBreakerResetEnvironments}
+          onResult={handleResult}
+        />
       </Box>
 
       {/* Database Refresh */}

--- a/src/components/AdminOperations/index.tsx
+++ b/src/components/AdminOperations/index.tsx
@@ -67,20 +67,8 @@ const AdminOperations = ({ hasKeyName }: AdminOperationsProps) => {
       </Box>
 
       {/* Circuit Breaker Reset */}
-      <Box sx={rowSx}>
+      <Box sx={{ mb: 4 }}>
         <CircuitBreakerCard onResult={handleResult} />
-        <InfoPanel
-          title="System Status"
-          note="Resetting signals every hub instance across all environments to restore connectivity."
-          rows={[
-            // TODO(IGDD-2272): Wire live hub status (active faults / regions /
-            // connection state) once a status source is available. AC #4's
-            // "redisplay shows the breaker was reset" will surface here.
-            { label: 'Active Faults', value: '—' },
-            { label: 'Regions', value: '—' },
-            { label: 'Status', value: '—' },
-          ]}
-        />
       </Box>
 
       {/* Database Refresh */}
@@ -95,9 +83,6 @@ const AdminOperations = ({ hasKeyName }: AdminOperationsProps) => {
           ]}
         />
       </Box>
-
-      {/* TODO(IGDD-2272): "Recent Audit Events" panel from the mockup — needs an
-          audit-event query wired up before it can display real data. */}
 
       <CustomSnackbar
         open={showSnackbar}

--- a/src/components/AdminOperations/index.tsx
+++ b/src/components/AdminOperations/index.tsx
@@ -7,11 +7,11 @@ import PasswordEncryptionCard from './PasswordEncryptionCard'
 import CircuitBreakerCard from './CircuitBreakerCard'
 import DatabaseRefreshCard from './DatabaseRefreshCard'
 import InfoPanel from './InfoPanel'
-import type { CircuitBreakerResetEnvironment } from '../../lib/utils/izghubcircuitbreakerreset'
+import type { HubEnvironment } from '../../lib/utils/izghubenvironments'
 
 interface AdminOperationsProps {
   hasKeyName: boolean
-  circuitBreakerResetEnvironments: CircuitBreakerResetEnvironment[]
+  hubEnvironments: HubEnvironment[]
 }
 
 // Two-column responsive grid: operation card on the left, info panel on the right.
@@ -24,7 +24,7 @@ const rowSx = {
 
 const AdminOperations = ({
   hasKeyName,
-  circuitBreakerResetEnvironments,
+  hubEnvironments,
 }: AdminOperationsProps) => {
   const { setAlert, alert } = React.useContext(CombinedContext)
   const [showSnackbar, setShowSnackbar] = React.useState(false)
@@ -74,19 +74,22 @@ const AdminOperations = ({
       {/* Circuit Breaker Reset */}
       <Box sx={{ mb: 4 }}>
         <CircuitBreakerCard
-          environments={circuitBreakerResetEnvironments}
+          environments={hubEnvironments}
           onResult={handleResult}
         />
       </Box>
 
       {/* Database Refresh */}
       <Box sx={rowSx}>
-        <DatabaseRefreshCard onResult={handleResult} />
+        <DatabaseRefreshCard
+          environments={hubEnvironments}
+          onResult={handleResult}
+        />
         <InfoPanel
           title="Configuration Sync"
-          note="Reloads each hub's configuration from the database across all environments."
+          note="Reloads the selected hub environment's configuration from the database."
           rows={[
-            { label: 'Scope', value: 'All hub environments' },
+            { label: 'Scope', value: 'Selected hub environment' },
             { label: 'Requires restart', value: 'No' },
           ]}
         />

--- a/src/lib/IZGHubStatusHistoryEndpoint.ts
+++ b/src/lib/IZGHubStatusHistoryEndpoint.ts
@@ -49,6 +49,6 @@ export default class IZGHubStatusHistoryEndpoint {
   }
 
   getIZGHubEndpointMetadata() {
-    return this.statusHistoryURLs
+    return [...this.statusHistoryURLs]
   }
 }

--- a/src/lib/IZGHubStatusHistoryEndpoint.ts
+++ b/src/lib/IZGHubStatusHistoryEndpoint.ts
@@ -3,7 +3,7 @@ import { StatusHistoryURLs } from './type/StatusHistoryURLs'
 import logger from '../../logger'
 
 export default class IZGHubStatusHistoryEndpoint {
-  statusHistoryURLs: StatusHistoryURLs
+  statusHistoryURLs: StatusHistoryURLs = []
 
   constructor(configuredStatusHistoryEndpoints: string) {
     try {
@@ -46,5 +46,9 @@ export default class IZGHubStatusHistoryEndpoint {
 
   getIZGHubURLs() {
     return this.statusHistoryURLs.map((endpoint) => endpoint.url)
+  }
+
+  getIZGHubEndpointMetadata() {
+    return this.statusHistoryURLs
   }
 }

--- a/src/lib/utils/izghubcircuitbreakerreset.ts
+++ b/src/lib/utils/izghubcircuitbreakerreset.ts
@@ -1,10 +1,10 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import axios from 'axios'
 import * as fs from 'fs'
 import path from 'path'
 import https from 'https'
 import IZGHubStatusHistoryEndpoint from '../IZGHubStatusHistoryEndpoint'
 import logger from '../../../logger'
+import { getDestinationType } from '../desttypehelper'
 
 /**
  * Hub circuit-breaker reset REST path, relative to the hub's `/rest/` base.
@@ -14,6 +14,24 @@ import logger from '../../../logger'
  */
 const CIRCUIT_BREAKER_RESET_PATH =
   process.env.IZG_CIRCUIT_BREAKER_RESET_PATH || 'reset'
+
+const ENVIRONMENT_LABELS: Record<string, string> = {
+  DEV: 'Development',
+  PRODUCTION: 'Production',
+  TEST: 'Testing',
+  ONBOARD: 'Onboarding',
+  STAGE: 'Staging',
+  UNKNOWN: 'Unknown',
+}
+
+const ENVIRONMENT_PRIORITY: Record<string, number> = {
+  PRODUCTION: 0,
+  ONBOARD: 1,
+  STAGE: 2,
+  DEV: 3,
+  TEST: 4,
+  UNKNOWN: 5,
+}
 
 const getHttpsAgentOptions = () => {
   const IZG_ENDPOINT_CRT_PATH = process.env.IZG_ENDPOINT_CRT_PATH || undefined
@@ -33,11 +51,96 @@ const getHttpsAgentOptions = () => {
 const deriveHubRestBaseUrl = (statusHistoryUrl: string) =>
   statusHistoryUrl.substring(0, statusHistoryUrl.indexOf('/rest/') + 6)
 
+const getConfiguredHubURLs = () =>
+  new IZGHubStatusHistoryEndpoint(process.env.IZG_STATUS_ENDPOINT_URL || '')
+
+const getEnvironmentLabel = (destinationTypeId: number, desc: string) => {
+  const destinationType = getDestinationType(destinationTypeId)
+  if (destinationType !== 'UNKNOWN') {
+    return ENVIRONMENT_LABELS[destinationType]
+  }
+
+  return desc || `Environment ${destinationTypeId}`
+}
+
+const resetCircuitBreakersForBaseUrls = async (
+  baseUrls: string[],
+  metadata?: { destinationTypeId?: number; destinationType?: string }
+): Promise<CircuitBreakerResetResult> => {
+  const httpsAgent = new https.Agent(getHttpsAgentOptions())
+
+  const outcomes = await Promise.allSettled(
+    baseUrls.map((baseUrl) => {
+      const url = `${baseUrl}${CIRCUIT_BREAKER_RESET_PATH}`
+      logger.info('Signaling hub to reset all circuit breakers', {
+        url,
+        operation: 'reset_circuit_breakers',
+        ...metadata,
+      })
+      return axios.post(url, null, { httpsAgent, timeout: 5000 })
+    })
+  )
+
+  const failed = outcomes.filter((o) => o.status === 'rejected')
+  failed.forEach((o) => {
+    if (o.status === 'rejected') {
+      logger.error('Hub circuit breaker reset failed', {
+        operation: 'reset_circuit_breakers',
+        ...metadata,
+        errorMessage: o.reason?.message,
+        statusCode: axios.isAxiosError(o.reason)
+          ? o.reason.response?.status
+          : undefined,
+      })
+    }
+  })
+
+  return {
+    attempted: outcomes.length,
+    succeeded: outcomes.length - failed.length,
+    failed: failed.length,
+  }
+}
+
 export interface CircuitBreakerResetResult {
   attempted: number
   succeeded: number
   failed: number
 }
+
+export interface CircuitBreakerResetEnvironment {
+  destinationTypeId: number
+  destinationType: string
+  label: string
+}
+
+export const getCircuitBreakerResetEnvironments =
+  (): CircuitBreakerResetEnvironment[] => {
+    const configuredHubURLs = getConfiguredHubURLs()
+    const environments = configuredHubURLs.getIZGHubEndpointMetadata().map(
+      ({ typeId, desc }) => {
+        const destinationType = getDestinationType(typeId)
+        return {
+          destinationTypeId: typeId,
+          destinationType,
+          label: getEnvironmentLabel(typeId, desc),
+        }
+      }
+    )
+
+    return Array.from(
+      new Map(
+        environments.map((environment) => [
+          environment.destinationTypeId,
+          environment,
+        ])
+      ).values()
+    ).sort(
+      (a, b) =>
+        (ENVIRONMENT_PRIORITY[a.destinationType] ?? 99) -
+        (ENVIRONMENT_PRIORITY[b.destinationType] ?? 99)
+    )
+  }
 
 /**
  * Signals every configured hub to reset all of its circuit breakers so
@@ -47,41 +150,23 @@ export interface CircuitBreakerResetResult {
  */
 export const resetAllCircuitBreakers =
   async (): Promise<CircuitBreakerResetResult> => {
-    const configuredHubURLs = new IZGHubStatusHistoryEndpoint(
-      process.env.IZG_STATUS_ENDPOINT_URL || ''
-    )
+    const configuredHubURLs = getConfiguredHubURLs()
     const baseUrls = Array.from(
       new Set(configuredHubURLs.getIZGHubURLs().map(deriveHubRestBaseUrl))
     )
-    const httpsAgent = new https.Agent(getHttpsAgentOptions())
 
-    const outcomes = await Promise.allSettled(
-      baseUrls.map((baseUrl) => {
-        const url = `${baseUrl}${CIRCUIT_BREAKER_RESET_PATH}`
-        logger.info('Signaling hub to reset all circuit breakers', {
-          url,
-          operation: 'reset_circuit_breakers',
-        })
-        return axios.post(url, null, { httpsAgent, timeout: 5000 })
-      })
-    )
-
-    const failed = outcomes.filter((o) => o.status === 'rejected')
-    failed.forEach((o) => {
-      if (o.status === 'rejected') {
-        logger.error('Hub circuit breaker reset failed', {
-          operation: 'reset_circuit_breakers',
-          errorMessage: o.reason?.message,
-          statusCode: axios.isAxiosError(o.reason)
-            ? o.reason.response?.status
-            : undefined,
-        })
-      }
-    })
-
-    return {
-      attempted: outcomes.length,
-      succeeded: outcomes.length - failed.length,
-      failed: failed.length,
-    }
+    return resetCircuitBreakersForBaseUrls(baseUrls)
   }
+
+export const resetCircuitBreakersForEnvironment = async (
+  destinationTypeId: number
+): Promise<CircuitBreakerResetResult> => {
+  const configuredHubURLs = getConfiguredHubURLs()
+  const statusHistoryUrl = configuredHubURLs.getIZGHubURL(destinationTypeId)
+  const destinationType = getDestinationType(destinationTypeId)
+
+  return resetCircuitBreakersForBaseUrls([deriveHubRestBaseUrl(statusHistoryUrl)], {
+    destinationTypeId,
+    destinationType,
+  })
+}

--- a/src/lib/utils/izghubcircuitbreakerreset.ts
+++ b/src/lib/utils/izghubcircuitbreakerreset.ts
@@ -15,24 +15,6 @@ import { getDestinationType } from '../desttypehelper'
 const CIRCUIT_BREAKER_RESET_PATH =
   process.env.IZG_CIRCUIT_BREAKER_RESET_PATH || 'reset'
 
-const ENVIRONMENT_LABELS: Record<string, string> = {
-  DEV: 'Development',
-  PRODUCTION: 'Production',
-  TEST: 'Testing',
-  ONBOARD: 'Onboarding',
-  STAGE: 'Staging',
-  UNKNOWN: 'Unknown',
-}
-
-const ENVIRONMENT_PRIORITY: Record<string, number> = {
-  PRODUCTION: 0,
-  ONBOARD: 1,
-  STAGE: 2,
-  DEV: 3,
-  TEST: 4,
-  UNKNOWN: 5,
-}
-
 const getHttpsAgentOptions = () => {
   const IZG_ENDPOINT_CRT_PATH = process.env.IZG_ENDPOINT_CRT_PATH || undefined
   const IZG_ENDPOINT_KEY_PATH = process.env.IZG_ENDPOINT_KEY_PATH || undefined
@@ -53,15 +35,6 @@ const deriveHubRestBaseUrl = (statusHistoryUrl: string) =>
 
 const getConfiguredHubURLs = () =>
   new IZGHubStatusHistoryEndpoint(process.env.IZG_STATUS_ENDPOINT_URL || '')
-
-const getEnvironmentLabel = (destinationTypeId: number, desc: string) => {
-  const destinationType = getDestinationType(destinationTypeId)
-  if (destinationType !== 'UNKNOWN') {
-    return ENVIRONMENT_LABELS[destinationType]
-  }
-
-  return desc || `Environment ${destinationTypeId}`
-}
 
 const resetCircuitBreakersForBaseUrls = async (
   baseUrls: string[],
@@ -107,40 +80,6 @@ export interface CircuitBreakerResetResult {
   succeeded: number
   failed: number
 }
-
-export interface CircuitBreakerResetEnvironment {
-  destinationTypeId: number
-  destinationType: string
-  label: string
-}
-
-export const getCircuitBreakerResetEnvironments =
-  (): CircuitBreakerResetEnvironment[] => {
-    const configuredHubURLs = getConfiguredHubURLs()
-    const environments = configuredHubURLs.getIZGHubEndpointMetadata().map(
-      ({ typeId, desc }) => {
-        const destinationType = getDestinationType(typeId)
-        return {
-          destinationTypeId: typeId,
-          destinationType,
-          label: getEnvironmentLabel(typeId, desc),
-        }
-      }
-    )
-
-    return Array.from(
-      new Map(
-        environments.map((environment) => [
-          environment.destinationTypeId,
-          environment,
-        ])
-      ).values()
-    ).sort(
-      (a, b) =>
-        (ENVIRONMENT_PRIORITY[a.destinationType] ?? 99) -
-        (ENVIRONMENT_PRIORITY[b.destinationType] ?? 99)
-    )
-  }
 
 /**
  * Signals every configured hub to reset all of its circuit breakers so

--- a/src/lib/utils/izghubdbrefresh.ts
+++ b/src/lib/utils/izghubdbrefresh.ts
@@ -1,10 +1,10 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import axios from 'axios'
 import * as fs from 'fs'
 import path from 'path'
 import https from 'https'
 import IZGHubStatusHistoryEndpoint from '../IZGHubStatusHistoryEndpoint'
 import logger from '../../../logger'
+import { getDestinationType } from '../desttypehelper'
 
 /**
  * Hub refresh REST path, relative to the hub's `/rest/` base. Signals a hub to
@@ -33,24 +33,19 @@ const getHttpsAgentOptions = () => {
 const deriveHubRestBaseUrl = (statusHistoryUrl: string) =>
   statusHistoryUrl.substring(0, statusHistoryUrl.indexOf('/rest/') + 6)
 
+const getConfiguredHubURLs = () =>
+  new IZGHubStatusHistoryEndpoint(process.env.IZG_STATUS_ENDPOINT_URL || '')
+
 export interface HubRefreshResult {
   attempted: number
   succeeded: number
   failed: number
 }
 
-/**
- * Signals every configured hub to refresh its configuration from the database,
- * across all Hub environments (IGDD-2272 global DB refresh). Mirrors the
- * https/cert handling used by the existing hub refresh + status-history calls.
- */
-export const refreshAllHubs = async (): Promise<HubRefreshResult> => {
-  const configuredHubURLs = new IZGHubStatusHistoryEndpoint(
-    process.env.IZG_STATUS_ENDPOINT_URL || ''
-  )
-  const baseUrls = Array.from(
-    new Set(configuredHubURLs.getIZGHubURLs().map(deriveHubRestBaseUrl))
-  )
+const refreshHubsForBaseUrls = async (
+  baseUrls: string[],
+  metadata?: { destinationTypeId?: number; destinationType?: string }
+): Promise<HubRefreshResult> => {
   const httpsAgent = new https.Agent(getHttpsAgentOptions())
 
   const outcomes = await Promise.allSettled(
@@ -59,6 +54,7 @@ export const refreshAllHubs = async (): Promise<HubRefreshResult> => {
       logger.info('Signaling hub to refresh from database', {
         url,
         operation: 'refresh_database',
+        ...metadata,
       })
       return axios.get(url, { httpsAgent, timeout: 5000 })
     })
@@ -69,6 +65,7 @@ export const refreshAllHubs = async (): Promise<HubRefreshResult> => {
     if (o.status === 'rejected') {
       logger.error('Hub database refresh failed', {
         operation: 'refresh_database',
+        ...metadata,
         errorMessage: o.reason?.message,
         statusCode: axios.isAxiosError(o.reason)
           ? o.reason.response?.status
@@ -82,4 +79,31 @@ export const refreshAllHubs = async (): Promise<HubRefreshResult> => {
     succeeded: outcomes.length - failed.length,
     failed: failed.length,
   }
+}
+
+/**
+ * Signals every configured hub to refresh its configuration from the database,
+ * across all Hub environments (IGDD-2272 global DB refresh). Mirrors the
+ * https/cert handling used by the existing hub refresh + status-history calls.
+ */
+export const refreshAllHubs = async (): Promise<HubRefreshResult> => {
+  const configuredHubURLs = getConfiguredHubURLs()
+  const baseUrls = Array.from(
+    new Set(configuredHubURLs.getIZGHubURLs().map(deriveHubRestBaseUrl))
+  )
+
+  return refreshHubsForBaseUrls(baseUrls)
+}
+
+export const refreshHubForEnvironment = async (
+  destinationTypeId: number
+): Promise<HubRefreshResult> => {
+  const configuredHubURLs = getConfiguredHubURLs()
+  const statusHistoryUrl = configuredHubURLs.getIZGHubURL(destinationTypeId)
+  const destinationType = getDestinationType(destinationTypeId)
+
+  return refreshHubsForBaseUrls([deriveHubRestBaseUrl(statusHistoryUrl)], {
+    destinationTypeId,
+    destinationType,
+  })
 }

--- a/src/lib/utils/izghubenvironments.ts
+++ b/src/lib/utils/izghubenvironments.ts
@@ -1,0 +1,50 @@
+import IZGHubStatusHistoryEndpoint from '../IZGHubStatusHistoryEndpoint'
+import desttypehelper, { getDestinationType } from '../desttypehelper'
+
+export interface HubEnvironment {
+  destinationTypeId: number
+  destinationType: string
+  label: string
+}
+
+const getConfiguredHubURLs = () =>
+  new IZGHubStatusHistoryEndpoint(process.env.IZG_STATUS_ENDPOINT_URL || '')
+
+const getEnvironmentLabel = (
+  destinationType: string,
+  destinationTypeId: number,
+  desc: string
+) => {
+  const label = desttypehelper.destTypeFormattedToSyncWithApi(destinationType)
+
+  if (label !== 'NA' && label !== 'UNKNOWN') {
+    return label
+  }
+
+  return desc || `Environment ${destinationTypeId}`
+}
+
+export const getHubEnvironments = (): HubEnvironment[] => {
+  const configuredHubURLs = getConfiguredHubURLs()
+  const environments = configuredHubURLs.getIZGHubEndpointMetadata().map(
+    ({ typeId, desc }) => {
+      const destinationType = getDestinationType(typeId)
+      return {
+        destinationTypeId: typeId,
+        destinationType,
+        label: getEnvironmentLabel(destinationType, typeId, desc),
+      }
+    }
+  )
+
+  // Preserve the order configured in IZG_STATUS_ENDPOINT_URL, deduping by
+  // destination type so a single environment renders one button.
+  return Array.from(
+    new Map(
+      environments.map((environment) => [
+        environment.destinationTypeId,
+        environment,
+      ])
+    ).values()
+  )
+}

--- a/src/pages/adminoperations/index.tsx
+++ b/src/pages/adminoperations/index.tsx
@@ -5,23 +5,39 @@ import AppHeaderBar from '../../components/AppHeader'
 import ErrorBoundary from '../../components/ErrorBoundary'
 import AdminOperations from '../../components/AdminOperations'
 import AdminGuard from '../../components/AdminGuard'
+import {
+  getCircuitBreakerResetEnvironments,
+  type CircuitBreakerResetEnvironment,
+} from '../../lib/utils/izghubcircuitbreakerreset'
 
-const AdminOperationsPage = ({ hasKeyName }: { hasKeyName: boolean }) => {
+interface AdminOperationsPageProps {
+  hasKeyName: boolean
+  circuitBreakerResetEnvironments: CircuitBreakerResetEnvironment[]
+}
+
+const AdminOperationsPage = ({
+  hasKeyName,
+  circuitBreakerResetEnvironments,
+}: AdminOperationsPageProps) => {
   return (
     <Container title="Admin Operations">
       <AppHeaderBar open />
       <ErrorBoundary>
-        <AdminOperations hasKeyName={hasKeyName} />
+        <AdminOperations
+          hasKeyName={hasKeyName}
+          circuitBreakerResetEnvironments={circuitBreakerResetEnvironments}
+        />
       </ErrorBoundary>
     </Container>
   )
 }
 
-export const getServerSideProps: GetServerSideProps<{
-  hasKeyName: boolean
-}> = async () => {
+export const getServerSideProps: GetServerSideProps<
+  AdminOperationsPageProps
+> = async () => {
   const hasKeyName = !!process.env.DB_ENCRYPTION_KEYNAME?.trim()
-  return { props: { hasKeyName } }
+  const circuitBreakerResetEnvironments = getCircuitBreakerResetEnvironments()
+  return { props: { hasKeyName, circuitBreakerResetEnvironments } }
 }
 
 export default AdminGuard(AdminOperationsPage)

--- a/src/pages/adminoperations/index.tsx
+++ b/src/pages/adminoperations/index.tsx
@@ -6,18 +6,18 @@ import ErrorBoundary from '../../components/ErrorBoundary'
 import AdminOperations from '../../components/AdminOperations'
 import AdminGuard from '../../components/AdminGuard'
 import {
-  getCircuitBreakerResetEnvironments,
-  type CircuitBreakerResetEnvironment,
-} from '../../lib/utils/izghubcircuitbreakerreset'
+  getHubEnvironments,
+  type HubEnvironment,
+} from '../../lib/utils/izghubenvironments'
 
 interface AdminOperationsPageProps {
   hasKeyName: boolean
-  circuitBreakerResetEnvironments: CircuitBreakerResetEnvironment[]
+  hubEnvironments: HubEnvironment[]
 }
 
 const AdminOperationsPage = ({
   hasKeyName,
-  circuitBreakerResetEnvironments,
+  hubEnvironments,
 }: AdminOperationsPageProps) => {
   return (
     <Container title="Admin Operations">
@@ -25,7 +25,7 @@ const AdminOperationsPage = ({
       <ErrorBoundary>
         <AdminOperations
           hasKeyName={hasKeyName}
-          circuitBreakerResetEnvironments={circuitBreakerResetEnvironments}
+          hubEnvironments={hubEnvironments}
         />
       </ErrorBoundary>
     </Container>
@@ -36,8 +36,8 @@ export const getServerSideProps: GetServerSideProps<
   AdminOperationsPageProps
 > = async () => {
   const hasKeyName = !!process.env.DB_ENCRYPTION_KEYNAME?.trim()
-  const circuitBreakerResetEnvironments = getCircuitBreakerResetEnvironments()
-  return { props: { hasKeyName, circuitBreakerResetEnvironments } }
+  const hubEnvironments = getHubEnvironments()
+  return { props: { hasKeyName, hubEnvironments } }
 }
 
 export default AdminGuard(AdminOperationsPage)

--- a/src/pages/api/status/refresh/index.ts
+++ b/src/pages/api/status/refresh/index.ts
@@ -1,16 +1,20 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import withMiddleware from '../../api-middleware-helper'
 import logger from '../../../../../logger'
-import { refreshAllHubs } from '../../../../lib/utils/izghubdbrefresh'
+import {
+  refreshAllHubs,
+  refreshHubForEnvironment,
+} from '../../../../lib/utils/izghubdbrefresh'
 
 /**
  * @swagger
  * /api/status/refresh:
  *   post:
- *     summary: Refresh all hubs' configuration from the database.
+ *     summary: Refresh hub configuration from the database.
  *     description: >
- *       Signals every configured hub to reload its configuration from the
- *       database across all Hub environments. Operations/admin users only.
+ *       Signals a configured hub environment, or every configured hub when no
+ *       destinationTypeId is provided, to reload its configuration from the
+ *       database. Operations/admin users only.
  *     responses:
  *       200:
  *         description: OK.
@@ -23,19 +27,41 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 
   try {
-    const result = await refreshAllHubs()
+    const hasDestinationTypeId =
+      req.body &&
+      Object.prototype.hasOwnProperty.call(req.body, 'destinationTypeId')
+    const destinationTypeId = Number(req.body?.destinationTypeId)
+    const isEnvironmentRefresh =
+      hasDestinationTypeId &&
+      Number.isInteger(destinationTypeId) &&
+      destinationTypeId > 0
+
+    if (hasDestinationTypeId && !isEnvironmentRefresh) {
+      return res.status(400).json({
+        success: false,
+        error: 'A valid destinationTypeId is required.',
+      })
+    }
+
+    const result = isEnvironmentRefresh
+      ? await refreshHubForEnvironment(destinationTypeId)
+      : await refreshAllHubs()
 
     if (result.attempted > 0 && result.succeeded === 0) {
       return res.status(502).json({
         success: false,
-        error: 'Failed to signal any hub instance to refresh from the database.',
+        error: isEnvironmentRefresh
+          ? 'Failed to signal the hub instance to refresh from the database.'
+          : 'Failed to signal any hub instance to refresh from the database.',
         result,
       })
     }
 
     return res.status(200).json({
       success: true,
-      message: 'Database refresh signaled to all hubs.',
+      message: isEnvironmentRefresh
+        ? 'Database refresh signaled for the selected environment.'
+        : 'Database refresh signaled to all hubs.',
       result,
     })
   } catch (err) {

--- a/src/pages/api/status/reset/index.ts
+++ b/src/pages/api/status/reset/index.ts
@@ -1,7 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import withMiddleware from '../../api-middleware-helper'
 import logger from '../../../../../logger'
-import { resetAllCircuitBreakers } from '../../../../lib/utils/izghubcircuitbreakerreset'
+import {
+  resetAllCircuitBreakers,
+  resetCircuitBreakersForEnvironment,
+} from '../../../../lib/utils/izghubcircuitbreakerreset'
 
 /**
  * @swagger
@@ -24,21 +27,43 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 
   try {
-    const result = await resetAllCircuitBreakers()
+    const hasDestinationTypeId =
+      req.body &&
+      Object.prototype.hasOwnProperty.call(req.body, 'destinationTypeId')
+    const destinationTypeId = Number(req.body?.destinationTypeId)
+    const isEnvironmentReset =
+      hasDestinationTypeId &&
+      Number.isInteger(destinationTypeId) &&
+      destinationTypeId > 0
+
+    if (hasDestinationTypeId && !isEnvironmentReset) {
+      return res.status(400).json({
+        success: false,
+        error: 'A valid destinationTypeId is required.',
+      })
+    }
+
+    const result = isEnvironmentReset
+      ? await resetCircuitBreakersForEnvironment(destinationTypeId)
+      : await resetAllCircuitBreakers()
 
     // Treat a total failure (every hub unreachable) as an error; partial success
     // still reports 200 so the operator sees that some hubs responded.
     if (result.attempted > 0 && result.succeeded === 0) {
       return res.status(502).json({
         success: false,
-        error: 'Failed to signal any hub instance to reset circuit breakers.',
+        error: isEnvironmentReset
+          ? 'Failed to signal the hub instance to reset circuit breakers.'
+          : 'Failed to signal any hub instance to reset circuit breakers.',
         result,
       })
     }
 
     return res.status(200).json({
       success: true,
-      message: 'All circuit breakers reset.',
+      message: isEnvironmentReset
+        ? 'Circuit breakers reset for the selected environment.'
+        : 'All circuit breakers reset.',
       result,
     })
   } catch (err) {


### PR DESCRIPTION
Also remove the TODO System Status card.

Before this PR- there was 1 button for on the /adminoperations page for Circuit Breaker Reset and Database Refresh.  If IZG_STATUS_ENDPOINT_URL had > 1 endpoint configured then clicking the one button would call the appropriate endpoints in both environments.  The mockups instead called for a button for each environment.