### PR TITLE
Prevent overwriting sibling connection row

### DIFF
--- a/src/components/ConnectionTable/index.tsx
+++ b/src/components/ConnectionTable/index.tsx
@@ -442,8 +442,9 @@ const ConnectionsTable = (props) => {
   const updateRow = useCallback(
     (row) => {
       const updatedEndpointStatus = endpointStatuses.map((x) => {
-        if (x.destId === row.destId) {
+        if (x.destId === row.destId && x.destTypeId === row.destTypeId) {
           return {
+            ...x,
             ...row,
           }
         } else {


### PR DESCRIPTION
updateRow matched on destId alone, so scheduling maintenance on one environment overwrote the Production row sharing that destId too, making it disappear until a manual refresh. Now matches on destId and destTypeId to update only the targeted row.